### PR TITLE
fix probability of TileSetItem

### DIFF
--- a/lib/tile_set/tile_set_item.dart
+++ b/lib/tile_set/tile_set_item.dart
@@ -24,7 +24,7 @@ class TileSetItem {
     image = json['image'];
     imageHeight = json['imageheight'];
     imageWidth = json['imagewidth'];
-    probability = json['probability'];
+    probability = json['probability']?.toDouble() ?? 0.0;
     if (json['terrain'] != null) {
       terrain = <int>[];
       json['terrain'].forEach((v) {


### PR DESCRIPTION
**Hi! The probability sometimes be int format in tileset.json，so jsonDecode will parse it to int**
**tiled version: 1.9.0**
**tileset.json**
![屏幕截图 2022-07-16 132549](https://user-images.githubusercontent.com/14236891/179341180-cfbfcc5e-dbfd-4741-bda4-3623b22d61a3.png)
**error**
![屏幕截图 2022-07-16 132622](https://user-images.githubusercontent.com/14236891/179341183-64e82d4c-6164-4669-bb9d-fa73289f22d1.png)
