### PR TITLE
Fix crash when WangColor probability is int

### DIFF
--- a/lib/tile_set/wang_color.dart
+++ b/lib/tile_set/wang_color.dart
@@ -10,7 +10,7 @@ class WangColor {
   WangColor.fromJson(Map<String, dynamic> json) {
     color = json['color'];
     name = json['name'];
-    probability = json['probability'];
+    probability = json['probability'].toDouble();
     tile = json['tile'];
     if (json['properties'] != null) {
       properties = <Property>[];


### PR DESCRIPTION
When loading a map created in Tiled, the WangColor.fromJson crashed due to `probability` being interpreted as an `int` with value `1`. This change converts the value to a `double`. 