### PR TITLE
Add repeatx and repeaty parsing

### DIFF
--- a/lib/map/layer/image_layer.dart
+++ b/lib/map/layer/image_layer.dart
@@ -4,17 +4,23 @@ class ImageLayer extends MapLayer {
   String image;
   double parallaxX;
   double parallaxY;
+  bool repeatX;
+  bool repeatY;
 
   ImageLayer({
     required this.image,
     this.parallaxX = 1,
     this.parallaxY = 1,
+    this.repeatX = false,
+    this.repeatY = false,
   });
 
   ImageLayer.fromJson(Map<String, dynamic> json)
       : image = json['image'],
         parallaxX = double.tryParse(json['parallaxx'].toString()) ?? 1,
-        parallaxY = double.tryParse(json['parallaxy'].toString()) ?? 1 {
+        parallaxY = double.tryParse(json['parallaxy'].toString()) ?? 1,
+        repeatX = json['repeatx'] ?? false,
+        repeatY = json['repeaty'] ?? false {
     setParamsFromJson(json);
   }
 


### PR DESCRIPTION
Hey, I noticed that the `repeatx` and `repeaty`properties are not getting parsed.

<img width="284" alt="grafik" src="https://github.com/RafaelBarbosatec/tiled_json_reader/assets/40323156/bd01e8b1-9ae5-4fab-8b2a-d73cdfb3e9bb">
